### PR TITLE
[#85]/fix 리마인드 환경설정 버튼 비활성화

### DIFF
--- a/web/src/components/common/ChipButton.tsx
+++ b/web/src/components/common/ChipButton.tsx
@@ -33,7 +33,7 @@ const ChipButtonStyled = styled.button<ButtonProps>`
       : css`
           color: ${props.theme.color.grayDark};
           border: 1px solid ${props.theme.color.grayLight};
-          \ &:disabled {
+          &:disabled {
             cursor: not-allowed;
           }
         `}

--- a/web/src/components/common/ChipButton.tsx
+++ b/web/src/components/common/ChipButton.tsx
@@ -23,10 +23,19 @@ const ChipButtonStyled = styled.button<ButtonProps>`
           color: ${props.theme.color.white};
           border: 1px solid ${props.theme.color.primary};
           background-color: ${props.theme.color.primary};
+          &:disabled {
+            background-color: ${props.theme.color.grayLightest};
+            border: none;
+            color: ${props.theme.color.gray};
+            cursor: not-allowed;
+          }
         `
       : css`
           color: ${props.theme.color.grayDark};
           border: 1px solid ${props.theme.color.grayLight};
+          \ &:disabled {
+            cursor: not-allowed;
+          }
         `}
 `;
 

--- a/web/src/components/mypage/Configuration.tsx
+++ b/web/src/components/mypage/Configuration.tsx
@@ -88,6 +88,7 @@ function Configuration(): ReactElement {
               <ChipButton
                 label={`${cycle}일`}
                 variant={cycle === selectedCycle ? 'primary' : 'secondary'}
+                disabled={!isRemind}
                 key={cycle}
                 onClick={() => {
                   mutateRemindCycleChange(cycle);


### PR DESCRIPTION
## 💁 이슈 넘버

[#85] : 리마인드 환경설정 버튼 비활성화

<br />

## 📘 작업 유형

- 버그 수정


<br/>

## 📑 작업리스트

> 작업한 목록

- 리마인드 환경설정 버튼 비활성화

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항

- 특이 사항 1
- 특이 사항 2
